### PR TITLE
Compatibility with bytestring-0.11.0.0

### DIFF
--- a/src/Data/Text/Format.hs
+++ b/src/Data/Text/Format.hs
@@ -25,7 +25,7 @@ module Data.Text.Format
 
 import           Control.Monad.IO.Class (MonadIO(liftIO))
 import qualified Data.ByteString.Lazy as L
-import qualified Data.ByteString.Lazy.Builder as L
+import qualified Data.ByteString.Builder as L
 import           Data.Text (Text)
 import qualified Data.Text as ST
 import qualified Data.Text as T

--- a/src/Formatting/Buildable.hs
+++ b/src/Formatting/Buildable.hs
@@ -39,7 +39,7 @@ import           Foreign.Ptr (IntPtr, WordPtr, Ptr, ptrToWordPtr)
 import qualified Data.Text as ST
 import qualified Data.Text.Lazy as LT
 import qualified Data.Text.Encoding as T
-import qualified Data.ByteString.Lazy.Builder as L
+import qualified Data.ByteString.Builder as L
 
 -- | The class of types that can be rendered to a 'Builder'.
 class Buildable p where


### PR DESCRIPTION
bytestring-0.11.0.0 removed the long deprecated `Data.ByteString.Lazy.Builder` module. This change also plays nicely with the projects lower bound of 0.10.4.0.

See https://hackage.haskell.org/package/bytestring-0.11.0.0/changelog for the full changelog. 