### PR TITLE
Add formatted combinator and FromBuilder typeclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Unreleased
+
+* Added `FromBuilder` and `formatted` to simplify using formatting with other APIs
+
 7.1.3
 
 * Fix the GHCJS build by not using `double-conversion`, as it relies on a native C library which obviously isn't available in GHCJS (it is still used in native builds).

--- a/README.md
+++ b/README.md
@@ -516,6 +516,22 @@ Now you can use it to maybe format things:
 "Nope!"
 ```
 
+## Using it with other APIs
+
+As a convenience, we provide the `FromBuilder` typeclass and the `formatted`
+combinator.  `formatted` makes it simple to add formatting to any API that is
+expecting a `Builder`, a strict or lazy `Text`, or a `String`. For example if
+you have functions `logDebug`, `logWarning` and `logInfo` all of type
+`Text -> IO ()` you can do the following:
+
+``` haskell
+> formatted logDebug ("x is: " % int) x
+> formatted logInfo ("y is: " % squared int) y
+> formatted logWarning ("z is: " % braced int) z
+```
+
+The above example will work for either strict or lazy `Text`
+
 ## Hacking
 
 ### Building with Nix

--- a/formatting.cabal
+++ b/formatting.cabal
@@ -72,6 +72,7 @@ library
     Formatting.Internal
     Formatting.Internal.Raw
     Formatting.Buildable
+    Formatting.FromBuilder
   other-modules:
     Data.Text.Format.Functions
     Data.Text.Format.Types

--- a/src/Formatting.hs
+++ b/src/Formatting.hs
@@ -37,6 +37,7 @@ module Formatting
   hprint,
   hprintLn,
   formatToString,
+  formatted,
   -- * Formatting library
   module Formatting.Formatters,
   module Formatting.Combinators
@@ -44,4 +45,5 @@ module Formatting
 
 import Formatting.Formatters
 import Formatting.Combinators
+import Formatting.FromBuilder
 import Formatting.Internal

--- a/src/Formatting/FromBuilder.hs
+++ b/src/Formatting/FromBuilder.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE FlexibleInstances #-}
+
+module Formatting.FromBuilder
+  ( FromBuilder(..)
+  , formatted
+  ) where
+
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+import Data.Text.Lazy.Builder (Builder)
+import qualified Data.Text.Lazy.Builder as TL
+import Formatting.Internal (Format (..))
+
+-- $setup
+-- >>> import qualified Data.Text.Lazy as TL (Text)
+-- >>> import qualified Data.Text.Lazy.IO as TL
+-- >>> import qualified Data.Text as T (Text)
+-- >>> import qualified Data.Text.IO as T
+-- >>> import Formatting ((%))
+-- >>> import Formatting.Formatters (int)
+-- >>> :set -XOverloadedStrings
+-- >>> :set -XTypeApplications
+
+-- | Anything that can be created from a 'Builder'.
+--   This class makes it easier to add formatting to other API's.
+--   See 'formatted' for some examples of this class in action.
+class FromBuilder a where
+  fromBuilder :: Builder -> a
+
+instance FromBuilder Builder where
+  fromBuilder = id
+  {-# INLINE fromBuilder #-}
+
+instance FromBuilder TL.Text where
+  fromBuilder = TL.toLazyText
+  {-# INLINE fromBuilder #-}
+
+instance FromBuilder T.Text where
+  fromBuilder = TL.toStrict . TL.toLazyText
+  {-# INLINE fromBuilder #-}
+
+instance FromBuilder [Char] where
+  fromBuilder = TL.unpack . TL.toLazyText
+  {-# INLINE fromBuilder #-}
+
+-- | Makes it easy to add formatting to any api that is expecting a builder,
+--   a strict or lazy text, or a string.
+--   It is essentially (flip runFormat), but with a more generous type due to
+--   the typeclass.
+--
+--   For example:
+--   >>> formatted TL.putStr ("x is: " % int % "\n") 7
+--   x is: 7
+--   >>> formatted T.putStr ("x is: " % int % "\n") 7
+--   x is: 7
+--   >>> formatted (id @TL.Text) ("x is: " % int % "\n") 7
+--   "x is: 7\n"
+--   >>> formatted (id @T.Text) ("x is: " % int % "\n") 7
+--   "x is: 7\n"
+formatted :: FromBuilder t => (t -> o) -> Format o a -> a
+formatted k f = runFormat f (k . fromBuilder)


### PR DESCRIPTION
Make it simple to add formatting to any API expecting a Builder or a strict or
lazy Text value. Logging is an obvious example, but there are plenty of others.