### PR TITLE
Fix haddock: escape quotes

### DIFF
--- a/src/Formatting.hs
+++ b/src/Formatting.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# OPTIONS -Wall #-}
 
--- $setup
--- >>> :set -XOverloadedStrings
 
 -- |
 -- Module      : Text.Format
@@ -47,7 +45,11 @@ module Formatting
   module Formatting.Combinators
  ) where
 
+
 import Formatting.Formatters
 import Formatting.Combinators
 import Formatting.FromBuilder
 import Formatting.Internal
+
+-- $setup
+-- >>> :set -XOverloadedStrings

--- a/src/Formatting/Formatters.hs
+++ b/src/Formatting/Formatters.hs
@@ -52,9 +52,6 @@ module Formatting.Formatters
   Buildable,
   ) where
 
--- $setup
--- >>> import Formatting.Internal
-
 import           Formatting.Internal
 
 import           Data.Char (chr, ord)
@@ -70,6 +67,9 @@ import           Data.Text.Lazy.Builder (Builder)
 import qualified Data.Text.Lazy.Builder as T
 import           Data.Text.Lazy.Builder.Scientific
 import           Numeric (showIntAtBase)
+
+-- $setup
+-- >>> import Formatting.Internal
 
 -- | Output a lazy text.
 text :: Format r (Text -> r)

--- a/src/Formatting/Internal.hs
+++ b/src/Formatting/Internal.hs
@@ -87,7 +87,7 @@ instance Monoid (Format r (a -> r)) where
   mempty = Format (\k _ -> k mempty)
 
 -- | Useful instance for writing format string. With this you can
--- write @"Foo"@ instead of @now "Foo!"@.
+-- write @\"Foo\"@ instead of @now "Foo!"@.
 instance (a ~ r) => IsString (Format r a) where
   fromString = now . fromString
 


### PR DESCRIPTION
"Foo" looks like a module name, even in code blocks.
I moved $setup blocks too, as they made at least haddock bundled
with ghc-8.8.4 fail to parse sources.