### PR TITLE
Spaced combination operator

### DIFF
--- a/src/Formatting.hs
+++ b/src/Formatting.hs
@@ -26,6 +26,7 @@ module Formatting
   (
   Format,
   (%),
+  (%%),
   (%.),
   now,
   later,

--- a/src/Formatting/Internal.hs
+++ b/src/Formatting/Internal.hs
@@ -6,6 +6,7 @@
 module Formatting.Internal
   ( Format(..)
   , (%)
+  , (%%)
   , (%.)
   , now
   , bind
@@ -35,6 +36,9 @@ import qualified Data.Text.Lazy.Builder as TLB
 import qualified Data.Text.Lazy.IO as T
 import           Prelude hiding ((.),id)
 import           System.IO
+
+-- $setup
+-- >>> import Formatting.Formatters
 
 -- | A formatter. When you construct formatters the first type
 -- parameter, @r@, will remain polymorphic.  The second type
@@ -136,6 +140,20 @@ instance Category Format where
 (%) :: Format r a -> Format r' r -> Format r' a
 (%) = (.)
 infixr 9 %
+
+-- | Concatenate two formatters with a space in between.
+--
+-- >>> :set -XOverloadedStrings
+-- >>> format (int %% "+" %% int %% "=" %% int) 2 3 5
+-- "2 + 3 = 5"
+--
+(%%) :: Format r a -> Format r' r -> Format r' a
+f %% g =
+    f `bind`
+    \a ->
+      g `bind`
+      \b -> now (a `mappend` TLB.singleton ' ' `mappend` b)
+infixr 9 %%
 
 -- | Function compose two formatters. Will feed the result of one
 -- formatter into another.

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -197,7 +197,7 @@ spec = do
     it "squared" $ format (squared int) 7 `shouldBe` "[7]"
     it "braced" $ format ("\\begin" % braced text) "section" `shouldBe` "\\begin{section}"
     it "angled" $ format (list (angled text)) ["html", "head", "title", "body", "div", "span"] `shouldBe` "[<html>, <head>, <title>, <body>, <div>, <span>]"
-    it "backticked" $ format ("Be sure to run " % backticked builder % " as root.") ":(){:|:&};:" `shouldBe` "Be sure to run `:(){:|:&};:` as root."
+    it "backticked" $ format ("Be sure to run" %% backticked builder %% "as root.") ":(){:|:&};:" `shouldBe` "Be sure to run `:(){:|:&};:` as root."
 
   describe "indenters" $ do
     it "indented" $ format (indented 4 int) 7 `shouldBe` "    7"


### PR DESCRIPTION
Related idea is to have `<+>` operator to do the same thing for `<>`. Then 

```haskell
let formatPeople = format (int % " " <> plural "person" "people" % ".")
```

could be written as

```haskell
let formatPeople = format (int <+> plural "person" "people" % ".")
```

if so, maybe `%%` should be named `%+`.
