### PR TITLE
allow Cabal 2.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: build
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ghc: ['9.2', '9.0', '8.10', '8.8', '8.6', '8.4']
+    name: Haskell GHC ${{ matrix.ghc }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: haskell/actions/setup@v1
+        with:
+          ghc-version: ${{ matrix.ghc }}
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cabal
+            dist-newstyle
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('**/*.cabal','**/cabal.project') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.ghc }}-
+            ${{ runner.os }}-
+      - run: cabal update
+      - run: cabal build
+      - run: cabal haddock
+      - run: cabal sdist
+      - run: cabal test

--- a/formatting.cabal
+++ b/formatting.cabal
@@ -1,4 +1,4 @@
-cabal-version:       2.4
+cabal-version:       2.2
 name:                formatting
 version:             7.1.3
 synopsis:            Combinator-based type-safe formatting (like printf() or FORMAT)


### PR DESCRIPTION
formatting seems to build just fine with Cabal-2.2

I also added a simple GH build CI action, which I hope may be useful